### PR TITLE
Updating naming for Conjur editions

### DIFF
--- a/conjur-jenkins/conjur-conn.md
+++ b/conjur-jenkins/conjur-conn.md
@@ -1,5 +1,5 @@
 
-The following steps define the connection to the DAP appliance. This is typically a one-time configuration.
+The following steps define the connection to the Conjur Enterprise appliance. This is typically a one-time configuration.
 
 You may need to login to Jenkins again after restart.
 Jenkins user name is `admin`{{copy}} and password is `344827fbdbfb40d5aac067c7a07b9230`{{copy}}
@@ -7,19 +7,19 @@ Jenkins user name is `admin`{{copy}} and password is `344827fbdbfb40d5aac067c7a0
 
 1. Navigate to Manage Jenkins > Manage Credentials > (global) > System > Add Credentials, the [Global credentials (unrestricted)](https://[[HOST_SUBDOMAIN]]-8081-[[KATACODA_HOST]].environments.katacoda.com//credentials/store/system/domain/_/newCredentials) page should be shown
 
-2. On the form that appears, configure the login credentials. These are credentials for the Jenkins host to log into DAP.
+2. On the form that appears, configure the login credentials. These are credentials for the Jenkins host to log into Conjur Enterprise.
 
 ![theimage](https://github.com/quincycheng/katacoda-scenarios/raw/master/conjur-jenkins/media/04-conn.PNG)
 
  - Username: `host/jenkins-frontend/frontend-01`{{copy}}
  - Password: 
 
-  Copy and paste the API key that was returned by DAP when you loaded the policy declaring this host.
+  Copy and paste the API key that was returned by Conjur Enterprise when you loaded the policy declaring this host.
   Forgot it?  No worries, execute `cat frontend.out`{{execute}} to review it
 
 3. Click Save.
 
-You can also decide whether to set up global or folder-level access to DAP, or a combination of both.
+You can also decide whether to set up global or folder-level access to Conjur Enterprise, or a combination of both.
 
 To learn more, visit [CyberArk Conjur Doc](https://docs.conjur.org/Latest/en/Content/Integrations/jenkins-configure.htm?tocpath=Integrations%7CJenkins%7C_____2#ConfigureJenkinsConjurconnection)
 

--- a/conjur-jenkins/index.json
+++ b/conjur-jenkins/index.json
@@ -47,7 +47,7 @@
         "text": "conjur-plugin.md"
       },
       {
-        "title": "Configure Jenkins-DAP connection",
+        "title": "Configure Jenkins-Conjur Enterprise connection",
         "text": "conjur-conn.md"
       },
       {

--- a/secretless-k8s-tutorial/intro.md
+++ b/secretless-k8s-tutorial/intro.md
@@ -9,7 +9,7 @@ In this scenario, you will get an overview of the Secretless Broker and learn ho
 ## What is Secretless Broker?
 With the Secretless Broker feature of Conjur, applications can securely connect to databases, services and other protected resources – without fetching or managing secrets.
 
-Secretless Broker is an independent and extensible open source community project maintained by CyberArk.  Today Secretless Broker works within Kubernetes and OpenShift container platforms with Conjur, Application Access Manager’s Dynamic Access Provider, and Kubernetes Secrets vaults.
+Secretless Broker is an independent and extensible open source community project maintained by CyberArk.  Today Secretless Broker works within Kubernetes and OpenShift container platforms with Conjur, Application Access Manager’s Conjur Enterprise, and Kubernetes Secrets vaults.
 
 <p align="center">
   <img width="300" height="300" src="https://www.conjur.org/wp-content/uploads/2019/07/secretless-arch-infographic.svg">


### PR DESCRIPTION
Updating naming for Conjur editions

- converts `Conjur OSS` to `Conjur Open Source`
- converts `DAP`/`Dynamic Access Provider` to `Conjur Enterprise`
- maintains `Conjur OSS Suite` and `Conjur Open Source Suite`

This is part of an automated batch of PRs across many repos listed in [cyberark/community#92](https://github.com/cyberark/community/issues/92)
